### PR TITLE
Remove special case for VSCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The detected color is provided by RGB or theme ( dark or light ).
 * [Tera Term](https://ttssh2.osdn.jp)
 * [Terminator](https://terminator-gtk3.readthedocs.io/en/latest/)
 * [tmux](https://github.com/tmux/tmux)
+* [Visual Studio Code](https://code.visualstudio.com)
 * xfce4-terminal
 * xterm
 * Win32 console
@@ -37,7 +38,6 @@ If you check other terminals, please report through [issue](https://github.com/d
 * [Poderosa](https://ja.poderosa-terminal.com)
 * [PuTTY](https://www.putty.org)
 * [QTerminal](https://github.com/lxqt/qterminal)
-* [Visual Studio Code](https://code.visualstudio.com)
 * [Windows Terminal](https://github.com/microsoft/terminal)
 
 "Windows Terminal" may be supported in a future release: https://github.com/microsoft/terminal/issues/3718.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@ pub enum Terminal {
     Tmux,
     XtermCompatible,
     Windows,
-    VSCode,
     Emacs,
 }
 
@@ -55,12 +54,6 @@ pub enum Error {
 /// get detected termnial
 #[cfg(not(target_os = "windows"))]
 pub fn terminal() -> Terminal {
-    if let Ok(term_program) = env::var("TERM_PROGRAM") {
-        if term_program == "vscode" {
-            return Terminal::VSCode;
-        }
-    }
-
     if env::var("INSIDE_EMACS").is_ok() {
         return Terminal::Emacs;
     }
@@ -86,7 +79,7 @@ pub fn terminal() -> Terminal {
 pub fn terminal() -> Terminal {
     if let Ok(term_program) = env::var("TERM_PROGRAM") {
         if term_program == "vscode" {
-            return Terminal::VSCode;
+            return Terminal::XtermCompatible;
         }
     }
 
@@ -127,7 +120,7 @@ pub fn rgb(timeout: Duration) -> Result<Rgb, Error> {
     let term = terminal();
     let rgb = match term {
         Terminal::Emacs => Err(Error::Unsupported),
-        Terminal::XtermCompatible | Terminal::VSCode => from_xterm(term, timeout),
+        Terminal::XtermCompatible => from_xterm(term, timeout),
         _ => from_winapi(),
     };
     let fallback = from_env_colorfgbg();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,6 @@ pub fn terminal() -> Terminal {
 pub fn rgb(timeout: Duration) -> Result<Rgb, Error> {
     let term = terminal();
     let rgb = match term {
-        Terminal::VSCode => Err(Error::Unsupported),
         Terminal::Emacs => Err(Error::Unsupported),
         _ => from_xterm(term, timeout),
     };
@@ -127,9 +126,8 @@ pub fn rgb(timeout: Duration) -> Result<Rgb, Error> {
 pub fn rgb(timeout: Duration) -> Result<Rgb, Error> {
     let term = terminal();
     let rgb = match term {
-        Terminal::VSCode => Err(Error::Unsupported),
         Terminal::Emacs => Err(Error::Unsupported),
-        Terminal::XtermCompatible => from_xterm(term, timeout),
+        Terminal::XtermCompatible | Terminal::VSCode => from_xterm(term, timeout),
         _ => from_winapi(),
     };
     let fallback = from_env_colorfgbg();
@@ -147,7 +145,6 @@ pub fn rgb(timeout: Duration) -> Result<Rgb, Error> {
 pub fn latency(timeout: Duration) -> Result<Duration, Error> {
     let term = terminal();
     match term {
-        Terminal::VSCode => Ok(Duration::from_millis(0)),
         Terminal::Emacs => Ok(Duration::from_millis(0)),
         _ => xterm_latency(timeout),
     }
@@ -158,7 +155,6 @@ pub fn latency(timeout: Duration) -> Result<Duration, Error> {
 pub fn latency(timeout: Duration) -> Result<Duration, Error> {
     let term = terminal();
     match term {
-        Terminal::VSCode => Ok(Duration::from_millis(0)),
         Terminal::Emacs => Ok(Duration::from_millis(0)),
         Terminal::XtermCompatible => xterm_latency(timeout),
         _ => Ok(Duration::from_millis(0)),


### PR DESCRIPTION
VSCode has supported OSC 11 for a [while now](https://github.com/microsoft/vscode/issues/139645).

I have tested this on my machine running Fedora 39 / VSCode 1.85.1. 

**Dark**:
![image](https://github.com/dalance/termbg/assets/4602612/242ece43-1998-4abc-9037-e8d05eff4b9d)

**Light**:
![image](https://github.com/dalance/termbg/assets/4602612/769fdd73-67f1-4d43-ba07-ede10acd1aba)
