### PR TITLE
feat: upgrade crossterm to 0.27.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ pre-release-replacements    = [
 ]
 
 [dependencies]
-async-std = "1.9.0"
-crossterm = "0.19"
+async-std = "1"
+crossterm = "0"
 thiserror = "1"
-is-terminal = "0.4.9"
+is-terminal = "0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["wincon", "winbase", "processenv", "impl-default"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,15 +36,10 @@ pub enum Theme {
 /// Error
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("terminal error")]
-    Terminal {
-        #[from]
-        source: crossterm::ErrorKind,
-    },
     #[error("io error")]
     Io {
         #[from]
-        source: std::io::Error,
+        source: io::Error,
     },
     #[error("parse error")]
     Parse(String),


### PR DESCRIPTION
The current crossterm version has a dependency to a mio version that has a vulnerability: https://github.com/tokio-rs/mio/security/advisories/GHSA-r8w9-5wcg-vfj7

This upgrade introduces a breaking change, as all results returned by crossterm are now standard `std:io::Result`, so there is no need to map crossterm errors anymore.

This PR would also close the dependabot PR: https://github.com/dalance/termbg/pull/16
