### PR TITLE
chore: remove unnecessary is-terminal dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ pre-release-replacements    = [
 async-std = "1"
 crossterm = "0.27"
 thiserror = "1"
-is-terminal = "0.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["wincon", "winbase", "processenv", "impl-default"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use crossterm::terminal;
-use is_terminal::IsTerminal;
 use std::env;
+use std::io::IsTerminal;
 use std::io::{self, Write};
 use std::time::{Duration, Instant};
 use thiserror::Error;


### PR DESCRIPTION
Let's just use `std::io::IsTerminal` :)
