### PR TITLE
fix: fix direct terminal is `tmux` if run `sudo` without `-E`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub fn terminal() -> Terminal {
         return Terminal::Emacs;
     }
 
-    if env::var("TMUX").is_ok() {
+    if env::var("TMUX").is_ok() || env::var("TERM").is_ok_and(|x| x.starts_with("tmux-")) {
         Terminal::Tmux
     } else {
         let is_screen = if let Ok(term) = env::var("TERM") {


### PR DESCRIPTION
The `TMUX` environment variable is not passed with `sudo` (if running `sudo` without `-E`), and detecting if the value of the `$TERM` variable is prefixed with `tmux` will make it possible to detect whether or not the `sudo` environment is `tmux` .