### PR TITLE
feat: add version command

### DIFF
--- a/src/bin/termbg.rs
+++ b/src/bin/termbg.rs
@@ -4,20 +4,26 @@ use std::env;
 fn main() {
     let args: Vec<String> = env::args().collect();
     let num_args = args.len();
-    match num_args {
-        1 => (),
-        2 if args[1] == "-d" || args[1] == "--debug" => {
-            CombinedLogger::init(vec![TermLogger::new(
-                LevelFilter::Debug,
-                Config::default(),
-                TerminalMode::Mixed,
-                ColorChoice::Auto,
-            )])
-            .unwrap();
-        }
-        _ => {
-            eprintln!("Usage: {} [--debug/-d]", args[0]);
-            std::process::exit(1);
+
+    if num_args > 1 {
+        match args[1].as_str() {
+            "--version" | "-V" => {
+                println!("termbg {}", env!("CARGO_PKG_VERSION"));
+                return;
+            }
+            "--debug" | "-d" => {
+                CombinedLogger::init(vec![TermLogger::new(
+                    LevelFilter::Debug,
+                    Config::default(),
+                    TerminalMode::Mixed,
+                    ColorChoice::Auto,
+                )])
+                .unwrap();
+            }
+            _ => {
+                eprintln!("Usage: {} [--debug/-d] [--version/-V]", args[0]);
+                std::process::exit(1);
+            }
         }
     }
 


### PR DESCRIPTION
👋 While [packaging termbg 0.6.1 for homebrew](https://github.com/Homebrew/homebrew-core/pull/201308), I noticed that there is no version command option, thus adding one (easier for passing CI). Thanks!

cc @dalance 